### PR TITLE
Use jsdelivr instead of raw github

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -254,7 +254,7 @@ const updateBypassDefinitions = callback => {
 							finishDownload()
 						}
 					}
-					xhr.open("GET", "https://raw.githubusercontent.com/FastForwardTeam/FastForward/" + upstreamCommit + "/src/js/injection_script.js", true)
+					xhr.open("GET", "https://cdn.jsdelivr.net/gh/FastForwardTeam/FastForward@" + upstreamCommit + "/src/js/injection_script.js", true)
 					xhr.send()
 					let xhr2 = new XMLHttpRequest()
 					xhr2.onload = () => {
@@ -270,7 +270,7 @@ const updateBypassDefinitions = callback => {
 							finishDownload()
 						}
 					}
-					xhr2.open("GET", "https://raw.githubusercontent.com/FastForwardTeam/FastForward/" + upstreamCommit + "/src/js/rules.json", true)
+					xhr2.open("GET", "https://cdn.jsdelivr.net/gh/FastForwardTeam/FastForward@" + upstreamCommit + "/src/js/rules.json", true)
 					xhr2.send()
 				}
 			}


### PR DESCRIPTION
<details> <summary>NOTICE</summary>
I dedicate any and all copyright interest in this software to the
public domain. I make this dedication for the benefit of the public at
large and to the detriment of my heirs and successors. I intend this
dedication to be an overt act of relinquishment in perpetuity of all
present and future rights to this software under copyright law.
</details>

Github blocks requests from Syria and Crimea and jsdelivr is MUCH faster

See: https://twitter.com/github/status/1346626296219099136

<!-- A breif description of what you did -->

<!--Add an x to mark as done-->
- [x] I made sure there are no unnecessary changes in the code*
- [x] Tested on Chromium- Chrome Windows
- [x] Tested on Firefox

\* indicates required
